### PR TITLE
bugs fixed

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -126,7 +126,7 @@ fi
 
 must_run unzip /tmp/flydav_install/flydav.zip -d /tmp/flydav_install
 
-must_run chmod +x /tmp/flydav_install/dist/linux_${ARCH}/flydav
+must_run chmod +x /tmp/flydav_install/flydav
 
 
 DOWNLOAD_CONFIG=1
@@ -181,7 +181,7 @@ EOF
         echo "Please enter a password for $USERNAME:"
         read -r PASSWORD
     done
-    PASSWORD_HASH=$(echo -n "$USERNAME" | sha256sum | cut -d ' ' -f 1)
+    PASSWORD_HASH=$(echo -n "$PASSWORD" | sha256sum | cut -d ' ' -f 1)
 
     FS_DIR=/tmp/flydav
     SUB_FS_DIR=
@@ -259,7 +259,7 @@ EOF
 fi
 
 echo "Installing binary"
-must_run mv "/tmp/flydav_install/dist/linux_${ARCH}/flydav" "/usr/local/bin/flydav"
+must_run mv "/tmp/flydav_install/flydav" "/usr/local/bin/flydav"
 
 # check if service is already installed
 if [ -f /etc/systemd/system/flydav.service ]; then


### PR DESCRIPTION
When I used the script to install on Linux-aarch64, I encountered an error. By reading the Shell code, I identified the issue.

In the previous installation, `flydav` might have been decompressed to `/tmp/flydav_install/dist/linux_${ARCH}/flydav`, but the current structure of `flydav.zip` does not include the `dist/linux_${ARCH}/` directory. Therefore, I removed the relevant lines of code, and the issue was resolved.

Additionally, I discovered another bug: the Shell script used `USERNAME` to generate the SHA256 password hash. To address this, I made the necessary fixes.
